### PR TITLE
Set version for cookbook 'apt' to work with vagrant box precise64

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -4,7 +4,7 @@
 site 'http://community.opscode.com/api/v1'
 
 
-cookbook 'apt'
+cookbook 'apt', '1.10.0'
 cookbook 'ntp'
 cookbook 'timezone', '0.0.1'
 cookbook 'networking_basic'


### PR DESCRIPTION
With the actual version for the cookbook 'apt'  2.0.0 it couldn't run with the original vagrant box precise64 or 32 because of chef version 10.X. The apt 2.0.0 needs min. chef 11.X. It use 'use_inline_ressources'.

Hope, i do the right thing with this pull request. I'm very new to GIT and GITHUB :)

Thx for sharing Ingo!
